### PR TITLE
Redefine the sysint sepolicy

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -41,7 +41,7 @@
 /system/bin/drmserver.samsung   u:object_r:drmserver_exec:s0
 /system/bin/gpsd                u:object_r:gpsd_exec:s0
 
-/system/etc/init.d/90userinit           u:object_r:userinit_exec:s0
+/system/etc/init.d/90userinit           u:object_r:seinit_exec:s0
 
 /sys/devices/platform/bcm4339_bluetooth/rfkill/rfkill0/state -- u:object_r:sysfs_bluetooth_writable:s0
 /sys/devices/platform/bcm4339_bluetooth/rfkill/rfkill0/type -- u:object_r:sysfs_bluetooth_writable:s0

--- a/sepolicy/sysinit.te
+++ b/sepolicy/sysinit.te
@@ -1,3 +1,3 @@
-type userinit_exec, exec_type, file_type;
+type seinit_exec, exec_type, file_type;
 allow sysinit self:capability { sys_module dac_override };
-allow sysinit userinit_exec:file getattr;
+allow sysinit seinit_exec:file getattr;


### PR DESCRIPTION
It was conflicting with some roms who define it in vendor
